### PR TITLE
LCT inventory change

### DIFF
--- a/src/main/java/be/uantwerpen/scicraft/block/LewisBlock.java
+++ b/src/main/java/be/uantwerpen/scicraft/block/LewisBlock.java
@@ -71,12 +71,7 @@ public class LewisBlock extends BlockWithEntity {
         if (state.getBlock() != newState.getBlock()) {
             BlockEntity blockEntity = world.getBlockEntity(pos);
             if (blockEntity instanceof LewisBlockEntity lewisBlockEntity) {
-                DefaultedList<ItemStack> items = lewisBlockEntity.getItems();
-                SimpleInventory inventory = new SimpleInventory(items.size() - GRIDSIZE);
-                for (int i = GRIDSIZE; i < items.size(); i++)
-                    inventory.addStack(items.get(i));
-                for (int i = 0; i < inventory.size(); i++)
-                    ItemScatterer.spawn(world, pos.getX(), pos.getY(), pos.getZ(), inventory.getStack(i));
+                ItemScatterer.spawn(world, pos, lewisBlockEntity.getIoInventory());
                 // update comparators
                 world.updateComparators(pos, this);
             }

--- a/src/main/java/be/uantwerpen/scicraft/block/entity/LewisBlockEntity.java
+++ b/src/main/java/be/uantwerpen/scicraft/block/entity/LewisBlockEntity.java
@@ -2,19 +2,19 @@ package be.uantwerpen.scicraft.block.entity;
 
 import be.uantwerpen.scicraft.crafting.CraftingRecipes;
 import be.uantwerpen.scicraft.gui.lewis_gui.LewisBlockScreenHandler;
-import be.uantwerpen.scicraft.inventory.ImplementedInventory;
 import be.uantwerpen.scicraft.crafting.lewis.LewisCraftingGrid;
 import be.uantwerpen.scicraft.crafting.lewis.MoleculeRecipe;
 import be.uantwerpen.scicraft.item.Items;
+import be.uantwerpen.scicraft.inventory.OrderedInventory;
 import be.uantwerpen.scicraft.network.LewisDataPacket;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.inventory.Inventories;
-import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.nbt.NbtElement;
 import net.minecraft.network.Packet;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.listener.ClientPlayPacketListener;
@@ -30,15 +30,16 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
-import static be.uantwerpen.scicraft.gui.lewis_gui.LewisBlockScreenHandler.GRIDSIZE;
+public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandlerFactory {
+    // slots 0-24
+    private final LewisCraftingGrid craftingGrid = new LewisCraftingGrid();
 
-public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandlerFactory, ImplementedInventory {
-    //Inventory of items
-    private final DefaultedList<ItemStack> inventory = DefaultedList.ofSize(36, ItemStack.EMPTY);
+    // slots 0-8: atoms, slot 9: erlenmeyer, slot 10: output
+    // combined with craftingGrid this gives slots 25-33: atoms, slot 34: erlenmeyer, slot 35: output
+    private final OrderedInventory ioInventory = new OrderedInventory(11);
+
     //PropertyDelegate is an interface which is implemented inline here.
     //It can normally contain multiple integers as data identified by the index.
     private final PropertyDelegate propertyDelegate;
@@ -61,26 +62,18 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
 
             @Override
             public int get(int index) {
-                switch (index) {
-                    case 0:
-                        return LewisBlockEntity.this.progress; //progress of the recipe
-                    case 1:
-                        return LewisBlockEntity.this.density; //Density (amount) of items needed for the recipe
-                    default:
-                        return 0;
-                }
+                return switch (index) {
+                    case 0 -> LewisBlockEntity.this.progress; //progress of the recipe
+                    case 1 -> LewisBlockEntity.this.density; //Density (amount) of items needed for the recipe
+                    default -> 0;
+                };
             }
 
             @Override
             public void set(int index, int value) {
                 switch (index) {
-                    case 0:
-                        LewisBlockEntity.this.progress = value;
-                        break;
-                    case 1:
-                        LewisBlockEntity.this.density = value;
-                        break;
-                    default:
+                    case 0 -> LewisBlockEntity.this.progress = value;
+                    case 1 -> LewisBlockEntity.this.density = value;
                 }
             }
 
@@ -91,22 +84,15 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
         };
     }
 
-    //From the ImplementedInventory Interface
-
-    @Override
-    public DefaultedList<ItemStack> getItems() {
-        return inventory;
-    }
 
     //These Methods are from the NamedScreenHandlerFactory Interface
     //createMenu creates the ScreenHandler itself
     //getDisplayName will Provide its name which is normally shown at the top
-
     @Override
     public ScreenHandler createMenu(int syncId, PlayerInventory playerInventory, PlayerEntity player) {
         //We provide *this* to the screenHandler as our class Implements Inventory
         //Only the Server has the Inventory at the start, this will be synced to the client in the ScreenHandler
-        return new LewisBlockScreenHandler(syncId, playerInventory, this, propertyDelegate, pos);
+        return new LewisBlockScreenHandler(syncId, playerInventory, craftingGrid, ioInventory, propertyDelegate, pos);
     }
 
     @Override
@@ -118,7 +104,8 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
     public void readNbt(NbtCompound nbt) {
         super.readNbt(nbt);
         this.progress = nbt.getInt("pr");
-        Inventories.readNbt(nbt, this.inventory);
+        this.craftingGrid.readNbtList(nbt.getList("grid", NbtElement.COMPOUND_TYPE));
+        this.ioInventory.readNbtList(nbt.getList("io_inv", NbtElement.COMPOUND_TYPE));
         this.density = nbt.getInt("dens");
 
     }
@@ -127,7 +114,8 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
     public void writeNbt(NbtCompound nbt) {
         super.writeNbt(nbt);
         nbt.putInt("pr", this.progress);
-        Inventories.writeNbt(nbt, this.inventory);
+        nbt.put("grid", craftingGrid.toNbtList());
+        nbt.put("io_inv", ioInventory.toNbtList());
         nbt.putInt("dens", this.density);
 
     }
@@ -146,7 +134,7 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
     public static void tick(World world, BlockPos pos, BlockState state, LewisBlockEntity lewis) {
         //No recipe loaded, try to load one.
         if (lewis.currentRecipe == null) {
-            Optional<MoleculeRecipe> recipe = lewis.matchGetter.getFirstMatch(lewis.getLewisCraftingGrid(), world);
+            Optional<MoleculeRecipe> recipe = lewis.matchGetter.getFirstMatch(lewis.craftingGrid, world);
             recipe.ifPresent(r -> {
                 lewis.ingredients = DefaultedList.ofSize(0);
                 lewis.currentRecipe = r;
@@ -157,12 +145,12 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
             });
         }
         //recipe loaded, check if enough items
-        else if (lewis.inventory.get(34).isEmpty() || lewis.inventory.get(34).isOf(lewis.currentRecipe.getOutput().getItem())){ //can output
-            if (!lewis.inventory.get(35).isOf(Items.ERLENMEYER) || lewis.inventory.get(35).getCount() < 1) return; //has erlenmeyer
+        else if (lewis.ioInventory.getStack(10).isEmpty() || lewis.ioInventory.getStack(10).isOf(lewis.currentRecipe.getOutput().getItem())){ //can output
+                if (!lewis.ioInventory.getStack(11).isOf(Items.ERLENMEYER) || lewis.ioInventory.getStack(11).getCount() < 1) return; //has erlenmeyer
             boolean correct = false;
             for (int i = 0; i < lewis.ingredients.size(); i++) {
                 correct = true;
-                if (!lewis.ingredients.get(i).test(lewis.inventory.get(GRIDSIZE+i)) || lewis.inventory.get(GRIDSIZE+i).getCount() < lewis.currentRecipe.getDensity()) {
+                if (!lewis.ingredients.get(i).test(lewis.ioInventory.getStack(i)) || lewis.ioInventory.getStack(i).getCount() < lewis.currentRecipe.getDensity()) {
                     correct = false; // not enough items
                     break;
                 }
@@ -177,15 +165,15 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
         if (lewis.progress > -1) {
             lewis.progress += 1;
             if (lewis.progress >= 23) { //Done crafting
-                if (lewis.inventory.get(34).isEmpty()) { //Set output slot
-                    lewis.inventory.set(34, lewis.currentRecipe.getOutput());
+                if (lewis.ioInventory.getStack(10).isEmpty()) { //Set output slot
+                    lewis.ioInventory.setStack(10, lewis.currentRecipe.getOutput());
                 }
                 else {
-                    lewis.inventory.get(34).increment(1);
+                    lewis.ioInventory.getStack(10).increment(1);
                 }
                 lewis.inventory.get(35).decrement(1);
                 for (int i = 0; i < lewis.ingredients.size(); i++) {
-                    lewis.inventory.get(GRIDSIZE+i).decrement(lewis.density);
+                    lewis.ioInventory.getStack(i).decrement(lewis.density);
                 }
                 lewis.resetRecipe();
             }
@@ -194,13 +182,12 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
     }
 
     public LewisCraftingGrid getLewisCraftingGrid() {
-        List<ItemStack> stacks = new ArrayList<>();
-        for (int i = 0; i < GRIDSIZE; i++) {
-            stacks.add(inventory.get(i));
-        }
-//        Scicraft.LOGGER.info("stacks: " + stacks);
+        return craftingGrid;
+    }
 
-        return new LewisCraftingGrid(5, 5,stacks.toArray(new ItemStack[0]));
+    public Inventory getIoInventory(){
+        return ioInventory;
+
     }
 
     /**

--- a/src/main/java/be/uantwerpen/scicraft/block/entity/LewisBlockEntity.java
+++ b/src/main/java/be/uantwerpen/scicraft/block/entity/LewisBlockEntity.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 
 public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandlerFactory {
     // slots 0-24
-    private final LewisCraftingGrid craftingGrid = new LewisCraftingGrid();
+    private final LewisCraftingGrid craftingGrid = new LewisCraftingGrid(5,5);
 
     // slots 0-8: atoms, slot 9: erlenmeyer, slot 10: output
     // combined with craftingGrid this gives slots 25-33: atoms, slot 34: erlenmeyer, slot 35: output
@@ -146,7 +146,8 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
         }
         //recipe loaded, check if enough items
         else if (lewis.ioInventory.getStack(10).isEmpty() || lewis.ioInventory.getStack(10).isOf(lewis.currentRecipe.getOutput().getItem())){ //can output
-                if (!lewis.ioInventory.getStack(11).isOf(Items.ERLENMEYER) || lewis.ioInventory.getStack(11).getCount() < 1) return; //has erlenmeyer
+            System.out.println(lewis.currentRecipe.getIngredients());
+            if (!lewis.ioInventory.getStack(9).isOf(Items.ERLENMEYER) || lewis.ioInventory.getStack(9).getCount() < 1) return; //has erlenmeyer
             boolean correct = false;
             for (int i = 0; i < lewis.ingredients.size(); i++) {
                 correct = true;
@@ -171,7 +172,7 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
                 else {
                     lewis.ioInventory.getStack(10).increment(1);
                 }
-                lewis.inventory.get(35).decrement(1);
+                lewis.ioInventory.getStack(9).decrement(1);
                 for (int i = 0; i < lewis.ingredients.size(); i++) {
                     lewis.ioInventory.getStack(i).decrement(lewis.density);
                 }

--- a/src/main/java/be/uantwerpen/scicraft/block/entity/LewisBlockEntity.java
+++ b/src/main/java/be/uantwerpen/scicraft/block/entity/LewisBlockEntity.java
@@ -141,7 +141,7 @@ public class LewisBlockEntity extends BlockEntity implements ExtendedScreenHandl
                 lewis.ingredients = r.getIngredients();
                 lewis.density = r.getDensity();
                 LewisDataPacket packet = new LewisDataPacket(pos, lewis.ingredients); //custom packet to sync ingredients
-                packet.sent(world, pos);
+                packet.send(world, pos);
             });
         }
         //recipe loaded, check if enough items

--- a/src/main/java/be/uantwerpen/scicraft/crafting/lewis/LewisCraftingGrid.java
+++ b/src/main/java/be/uantwerpen/scicraft/crafting/lewis/LewisCraftingGrid.java
@@ -5,15 +5,18 @@ import be.uantwerpen.scicraft.crafting.molecules.Bond;
 import be.uantwerpen.scicraft.crafting.molecules.MoleculeItemGraph;
 import be.uantwerpen.scicraft.crafting.molecules.PartialMolecule;
 import be.uantwerpen.scicraft.item.AtomItem;
-import net.minecraft.inventory.SimpleInventory;
+import be.uantwerpen.scicraft.inventory.OrderedInventory;
 import net.minecraft.item.ItemStack;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Stream;
 
-public class LewisCraftingGrid extends SimpleInventory {
+public class LewisCraftingGrid extends OrderedInventory {
 
-    private PartialMolecule currentMolecule = null;
+    private PartialMolecule currentMolecule = new PartialMolecule();
 
     private int width = 5;
     private int height = 5;

--- a/src/main/java/be/uantwerpen/scicraft/crafting/molecules/PartialMolecule.java
+++ b/src/main/java/be/uantwerpen/scicraft/crafting/molecules/PartialMolecule.java
@@ -6,6 +6,10 @@ public class PartialMolecule {
 
     private final MoleculeGraph structure;
 
+    public PartialMolecule(){
+        this(new MoleculeGraph());
+    }
+
     public PartialMolecule(MoleculeGraph structure){
         this.structure = structure;
     }

--- a/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisBlockScreenHandler.java
+++ b/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisBlockScreenHandler.java
@@ -32,6 +32,7 @@ public class LewisBlockScreenHandler extends ScreenHandler {
 
     // size of inventory without grid
     private final int INVENTORY_SIZE = 11;
+    public static final int GRIDSIZE = 25;
 
     private final LewisCraftingGrid craftingGrid;
 
@@ -57,7 +58,7 @@ public class LewisBlockScreenHandler extends ScreenHandler {
      * @param buf
      */
     public LewisBlockScreenHandler(int syncId, PlayerInventory playerInventory, PacketByteBuf buf) {
-        this(syncId, playerInventory, new LewisCraftingGrid(), new OrderedInventory(11), new ArrayPropertyDelegate(2), buf.readBlockPos());
+        this(syncId, playerInventory, new LewisCraftingGrid(5,5), new OrderedInventory(11), new ArrayPropertyDelegate(2), buf.readBlockPos());
     }
 
     /**
@@ -87,7 +88,7 @@ public class LewisBlockScreenHandler extends ScreenHandler {
         this.addListener(new ScreenHandlerListener() {
             @Override
             public void onSlotUpdate(ScreenHandler handler, int slotId, ItemStack stack) {
-                if (slotId < LewisCraftingGrid.GRIDSIZE) {
+                if (slotId < GRIDSIZE) {
                     lewis.resetRecipe();
                     handler.onContentChanged(craftingGrid);
                 }else{

--- a/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisBlockScreenHandler.java
+++ b/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisBlockScreenHandler.java
@@ -30,6 +30,9 @@ import java.util.List;
 
 public class LewisBlockScreenHandler extends ScreenHandler {
 
+    // size of inventory without grid
+    private final int INVENTORY_SIZE = 11;
+
     private final LewisCraftingGrid craftingGrid;
 
     private final Inventory ioInventory;
@@ -197,7 +200,11 @@ public class LewisBlockScreenHandler extends ScreenHandler {
         if (slot.hasStack()) {
             ItemStack itemStack2 = slot.getStack();
             itemStack = itemStack2.copy();
-            if (!this.insertItem(itemStack2, GRIDSIZE, GRIDSIZE + this.ioInventory.size(), false)) { //start from slot GRIDSIZE, this is outside of the grid.
+            if (invSlot < GRIDSIZE + INVENTORY_SIZE) {
+                if (!this.insertItem(itemStack2, GRIDSIZE + INVENTORY_SIZE, this.slots.size(), true)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (!this.insertItem(itemStack2, GRIDSIZE, GRIDSIZE + INVENTORY_SIZE, false)) { //start from slot GRIDSIZE, this is outside of the grid.
                 return ItemStack.EMPTY;
             }
 
@@ -210,6 +217,7 @@ public class LewisBlockScreenHandler extends ScreenHandler {
 
         return itemStack;
     }
+
 
     /**
      * Inserts the item into a slot, trying indexes from {@param startIndex} to {@param endIndex}.

--- a/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisBlockScreenHandler.java
+++ b/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisBlockScreenHandler.java
@@ -197,12 +197,7 @@ public class LewisBlockScreenHandler extends ScreenHandler {
         if (slot.hasStack()) {
             ItemStack itemStack2 = slot.getStack();
             itemStack = itemStack2.copy();
-            if (invSlot - GRIDSIZE < this.ioInventory.size()) {
-                // TODO: the statement below doesn't seem to do anything (inventory size and slot size should be equal).
-                if (!this.insertItem(itemStack2, this.ioInventory.size(), this.slots.size(), true)) {
-                    return ItemStack.EMPTY;
-                }
-            } else if (!this.insertItem(itemStack2, GRIDSIZE, this.ioInventory.size(), false)) { //start from slot GRIDSIZE, this is outside of the grid.
+            if (!this.insertItem(itemStack2, GRIDSIZE, GRIDSIZE + this.ioInventory.size(), false)) { //start from slot GRIDSIZE, this is outside of the grid.
                 return ItemStack.EMPTY;
             }
 

--- a/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisBlockScreenHandler.java
+++ b/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisBlockScreenHandler.java
@@ -36,6 +36,7 @@ public class LewisBlockScreenHandler extends ScreenHandler {
 
     //PropertyDelegate that holds the progress and density
     private final PropertyDelegate propertyDelegate;
+
     //The LewisBlockEntity that belongs to the screen. Can be used to get extra data, as long as that data is synced
     private LewisBlockEntity lewis;
 

--- a/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisScreen.java
+++ b/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisScreen.java
@@ -50,7 +50,6 @@ public class LewisScreen extends HandledScreen<LewisBlockScreenHandler> implemen
      */
     @Override
     protected void drawBackground(MatrixStack matrices, float delta, int mouseX, int mouseY) {
-
         RenderSystem.setShader(GameRenderer::getPositionTexShader);
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.setShaderTexture(0, getCorrectTexture());

--- a/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisScreen.java
+++ b/src/main/java/be/uantwerpen/scicraft/gui/lewis_gui/LewisScreen.java
@@ -68,19 +68,20 @@ public class LewisScreen extends HandledScreen<LewisBlockScreenHandler> implemen
         // Keep mapping between stack (in graph) and slots (for rendering)
         Map<ItemStack, Slot> stackToSlotMap = new HashMap<>();
         for (int i = 0; i < GRIDSIZE; i++) {
-            stackToSlotMap.put(handler.getInventory().getStack(i), handler.getSlot(i));
+            stackToSlotMap.put(handler.getLewisCraftingGrid().getStack(i), handler.getSlot(i));
         }
 
         /*
          * Draw Bonds on screen
          */
         LewisCraftingGrid grid = handler.getLewisCraftingGrid();
-        MoleculeItemGraph graph = (MoleculeItemGraph) grid.getPartialMolecule().getStructure();
-        for (MoleculeItemGraph.Edge edge : graph.getEdges()) {
-            Slot slot1 = stackToSlotMap.get(graph.getItemStackOfVertex(edge.getFirst()));
-            Slot slot2 = stackToSlotMap.get(graph.getItemStackOfVertex(edge.getSecond()));
-            BondManager.Bond bond = new BondManager.Bond(slot1, slot2, edge.data.bondOrder);
-            this.itemRenderer.renderInGuiWithOverrides(bond.getStack(), bond.getX() + x, bond.getY() + y);
+        if (grid.getPartialMolecule().getStructure() instanceof MoleculeItemGraph graph){
+            for (MoleculeItemGraph.Edge edge : graph.getEdges()) {
+                Slot slot1 = stackToSlotMap.get(graph.getItemStackOfVertex(edge.getFirst()));
+                Slot slot2 = stackToSlotMap.get(graph.getItemStackOfVertex(edge.getSecond()));
+                BondManager.Bond bond = new BondManager.Bond(slot1, slot2, edge.data.bondOrder);
+                this.itemRenderer.renderInGuiWithOverrides(bond.getStack(), bond.getX() + x, bond.getY() + y);
+            }
         }
 
         /*
@@ -92,7 +93,7 @@ public class LewisScreen extends HandledScreen<LewisBlockScreenHandler> implemen
             if(!this.handler.hasRecipe() || atom.isEmpty()) {
                 break;
             }
-            if (handler.getInventory().getStack(GRIDSIZE+i).getCount() < handler.getDensity()) {
+            if (handler.getIoInventory().getStack(i).getCount() < handler.getDensity()) {
                 this.itemRenderer.renderInGuiWithOverrides(new ItemStack(Items.RED_STAINED_GLASS_PANE), x + 8 + 18*i, 133+y-20);
             } else {
                 this.itemRenderer.renderInGuiWithOverrides(new ItemStack(Items.GREEN_STAINED_GLASS_PANE), x + 8 + 18*i, 133+y-20);

--- a/src/main/java/be/uantwerpen/scicraft/inventory/OrderedInventory.java
+++ b/src/main/java/be/uantwerpen/scicraft/inventory/OrderedInventory.java
@@ -1,0 +1,50 @@
+package be.uantwerpen.scicraft.inventory;
+
+import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtList;
+import net.minecraft.util.collection.DefaultedList;
+
+/**
+ * Extension of {@link net.minecraft.inventory.SimpleInventory} that keeps track of position of items in inventory.
+ */
+public class OrderedInventory extends SimpleInventory {
+
+    public OrderedInventory(int size) {
+        super(size);
+    }
+
+    public OrderedInventory(ItemStack ... items) {
+        super(items);
+    }
+
+    @Override
+    public void readNbtList(NbtList nbtList) {
+        int i;
+        for (i = 0; i < this.size(); ++i) {
+            this.setStack(i, ItemStack.EMPTY);
+        }
+        for (i = 0; i < nbtList.size(); ++i) {
+            NbtCompound nbtCompound = nbtList.getCompound(i);
+            int j = nbtCompound.getByte("Slot") & 0xFF;
+            if (j < 0 || j >= this.size()) continue;
+            this.setStack(j, ItemStack.fromNbt(nbtCompound));
+        }
+    }
+
+    @Override
+    public NbtList toNbtList() {
+        NbtList nbtList = new NbtList();
+        for (int i = 0; i < this.size(); ++i) {
+            ItemStack itemStack = this.getStack(i);
+            if (itemStack.isEmpty()) continue;
+            NbtCompound nbtCompound = new NbtCompound();
+            nbtCompound.putByte("Slot", (byte)i);
+            itemStack.writeNbt(nbtCompound);
+            nbtList.add(nbtCompound);
+        }
+        return nbtList;
+    }
+
+}

--- a/src/main/java/be/uantwerpen/scicraft/network/LewisDataPacket.java
+++ b/src/main/java/be/uantwerpen/scicraft/network/LewisDataPacket.java
@@ -58,7 +58,7 @@ public class LewisDataPacket {
         }
     }
 
-    public void sent(World world, BlockPos pos) {
+    public void send(World world, BlockPos pos) {
         if (world.isClient) {
             return;
         }

--- a/src/main/java/be/uantwerpen/scicraft/util/Graph.java
+++ b/src/main/java/be/uantwerpen/scicraft/util/Graph.java
@@ -19,25 +19,25 @@ public class Graph<V, E> {
     public class Vertex {
         public V data;
 
-        private final LinkedHashSet<Edge> edges = new LinkedHashSet<>();
+        private final List<Edge> edges = new ArrayList<>();
 
         private Vertex(V data) {
             this.data = data;
         }
 
-        public Collection<Vertex> getNeighbours() {
-            return edges.stream().flatMap(edge -> edge.getVertices().stream().filter(vertex -> vertex != this)).collect(Collectors.toSet());
+        public List<Vertex> getNeighbours() {
+            return edges.stream().flatMap(edge -> edge.getVertices().stream().filter(vertex -> vertex != this)).collect(Collectors.toList());
         }
 
-        public Collection<V> getNeighboursData() {
+        public List<V> getNeighboursData() {
             return getNeighbours().stream().map(vertex -> vertex.data).collect(Collectors.toList());
         }
 
-        public Collection<Edge> getEdges() {
+        public List<Edge> getEdges() {
             return edges;
         }
 
-        public Collection<E> getEdgesData() {
+        public List<E> getEdgesData() {
             return edges.stream().map(edge -> edge.data).collect(Collectors.toList());
         }
 
@@ -89,11 +89,11 @@ public class Graph<V, E> {
         }
     }
 
-    protected final LinkedHashSet<Vertex> vertices = new LinkedHashSet<>();
+    protected final List<Vertex> vertices = new ArrayList<>();
 
     protected final LinkedHashMap<Set<Vertex>, Edge> edges = new LinkedHashMap<>();
 
-    public Set<Vertex> getVertices() {
+    public List<Vertex> getVertices() {
         return vertices;
     }
 


### PR DESCRIPTION
change how inventories work in LCT. It now has two separate inventories rather than being one.

Slot indices are also updated. Previously the order was grid, input slots below, output slot, erlenmeyer slot.
I moved the erlenmeyer slot in front of the output (so it is together with the other inputs).

Need to test whether old functionality is still there.

Closes #192 