### PR TITLE
Entropy fixes

### DIFF
--- a/src/main/java/be/uantwerpen/minelabs/entity/Entities.java
+++ b/src/main/java/be/uantwerpen/minelabs/entity/Entities.java
@@ -83,7 +83,7 @@ public class Entities {
     public static void registerEntities() {
         Minelabs.LOGGER.info("registering entities");
         FabricDefaultAttributeRegistry.register(ENTROPY_CREEPER, EntropyCreeperEntity.createCreeperAttributes());
-        registerEntitySpawns(ENTROPY_CREEPER, BiomeSelectors.foundInOverworld().and(BiomeSelectors.foundInTheNether()),
-                new SpawnSettings.SpawnEntry(ENTROPY_CREEPER, 100, 1, 1));
+        registerEntitySpawns(ENTROPY_CREEPER, BiomeSelectors.foundInOverworld().or(BiomeSelectors.foundInTheNether()),
+                new SpawnSettings.SpawnEntry(ENTROPY_CREEPER, 100, 0, 1));
     }
 }

--- a/src/main/java/be/uantwerpen/minelabs/entity/Entities.java
+++ b/src/main/java/be/uantwerpen/minelabs/entity/Entities.java
@@ -83,7 +83,7 @@ public class Entities {
     public static void registerEntities() {
         Minelabs.LOGGER.info("registering entities");
         FabricDefaultAttributeRegistry.register(ENTROPY_CREEPER, EntropyCreeperEntity.createCreeperAttributes());
-        registerEntitySpawns(ENTROPY_CREEPER, BiomeSelectors.all(),
+        registerEntitySpawns(ENTROPY_CREEPER, BiomeSelectors.foundInOverworld().and(BiomeSelectors.foundInTheNether()),
                 new SpawnSettings.SpawnEntry(ENTROPY_CREEPER, 100, 1, 1));
     }
 }

--- a/src/main/java/be/uantwerpen/minelabs/entity/EntropyCreeperEntity.java
+++ b/src/main/java/be/uantwerpen/minelabs/entity/EntropyCreeperEntity.java
@@ -3,6 +3,7 @@ package be.uantwerpen.minelabs.entity;
 import be.uantwerpen.minelabs.Minelabs;
 import be.uantwerpen.minelabs.mixins.ExplosionAccessor;
 import be.uantwerpen.minelabs.sound.SoundEvents;
+import be.uantwerpen.minelabs.util.Tags;
 import com.google.common.collect.Sets;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -192,6 +193,7 @@ public class EntropyCreeperEntity extends CreeperEntity {
     public boolean preExplode() {
         if (!this.world.isClient) {
             dead = true;
+            this.setInvulnerable(true);
             setInvisible(true);     // so we can't see it (discard happens after animation)
             // TODO: entity can still be attacked in this state.
             //  Either prevent this or have the entropy creeper spawn an entropy bomb upon explode?
@@ -269,6 +271,7 @@ public class EntropyCreeperEntity extends CreeperEntity {
      * @return whether the block should be movable.
      */
     private boolean isShuffleable(BlockState blockState) {
-        return !blockState.isIn(BlockTags.DRAGON_IMMUNE);
+        return !blockState.isIn(BlockTags.DRAGON_IMMUNE) &&
+                !blockState.isIn(Tags.Blocks.ENTROPY_IMMUNE);
     }
 }

--- a/src/main/java/be/uantwerpen/minelabs/util/Tags.java
+++ b/src/main/java/be/uantwerpen/minelabs/util/Tags.java
@@ -21,6 +21,7 @@ public class Tags {
         public static final TagKey<Block> LASERTOOL_MINEABLE = createTag("lasertool_mineable");
         public static final TagKey<Block> COPPER_BLOCKS = createTag("copper_blocks");
         public static final TagKey<Block> CHARGED_BLOCKS = createTag("charged_blocks");
+        public static final TagKey<Block> ENTROPY_IMMUNE = createTag("entropy_immune");
 
         /**
          * Create a Block tag (tag is only used inside this mod)

--- a/src/main/resources/data/minelabs/tags/blocks/entropy_immune.json
+++ b/src/main/resources/data/minelabs/tags/blocks/entropy_immune.json
@@ -1,0 +1,14 @@
+{
+  "replace": false,
+  "values": [
+    "minelabs:atomic_floor",
+    "minelabs:bohr_block",
+    "minelabs:upquark_quantumfield",
+    "minelabs:downquark_quantumfield",
+    "minelabs:gluon_quantumfield",
+    "minelabs:electron_quantumfield",
+    "minelabs:photon_quantumfield",
+    "minelabs:neutrino_quantumfield",
+    "minelabs:weak_boson_quantumfield"
+  ]
+}

--- a/src/main/resources/data/minelabs/tags/blocks/entropy_immune.json
+++ b/src/main/resources/data/minelabs/tags/blocks/entropy_immune.json
@@ -9,6 +9,11 @@
     "minelabs:electron_quantumfield",
     "minelabs:photon_quantumfield",
     "minelabs:neutrino_quantumfield",
-    "minelabs:weak_boson_quantumfield"
+    "minelabs:weak_boson_quantumfield",
+    "minecraft:sticky_piston",
+    "minecraft:piston",
+    "minecraft:piston_head",
+    "c:shulker_boxes",
+    "c:chests"
   ]
 }

--- a/src/main/resources/data/minelabs/tags/blocks/entropy_immune.json
+++ b/src/main/resources/data/minelabs/tags/blocks/entropy_immune.json
@@ -13,7 +13,7 @@
     "minecraft:sticky_piston",
     "minecraft:piston",
     "minecraft:piston_head",
-    "c:shulker_boxes",
-    "c:chests"
+    "minecraft:shulker_box",
+    "minecraft:chests"
   ]
 }


### PR DESCRIPTION
fixes  #256, fixes #310 ,fixes   #358 
Added custom tag: ENTROPY_IMMUNE
Changed amount of entropy creepers spawning and there Biome selection.
Was ALL BIOMES (even custom ones), now only in all the Overworld and Nether ones.