### PR TITLE
Fixed rendering Mologram hopper extraction

### DIFF
--- a/src/main/java/be/uantwerpen/minelabs/block/entity/MologramBlockEntity.java
+++ b/src/main/java/be/uantwerpen/minelabs/block/entity/MologramBlockEntity.java
@@ -46,6 +46,9 @@ public class MologramBlockEntity extends BlockEntity implements ImplementedInven
         } else {
             //CLIENT
             entity.rotation = (entity.rotation + 3.6f) % 360f;
+            if (!state.get(Properties.LIT) && !entity.getStack(0).isEmpty()) {
+                entity.setStack(0, ItemStack.EMPTY);
+            }
         }
     }
 


### PR DESCRIPTION
When a hopper extracts the item from the Mologram it used to detect this and send an update to the client as wanted.
Tho this only updated the BlockState property LIT, thus disabling the glow, but it did not update the block's inventory.

By detecting when the glow had been disabled I was able to clear the item from the mologram's inventory on the client side to match the server.

With this, issue #429 has been resolved.